### PR TITLE
update notification message

### DIFF
--- a/.github/workflows/slack-notif.yml
+++ b/.github/workflows/slack-notif.yml
@@ -35,7 +35,7 @@ jobs:
           channel-id: ${{ inputs.channel-id }}
           payload: |
             {
-              "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "text": "${{ inputs.component }} deployment ${{ inputs.region }} ${{ inputs.status }}",
               "blocks": [
               {
                 "type": "section",


### PR DESCRIPTION
[`text` is used as notification when `blocks` is present.]( https://api.slack.com/methods/chat.postMessage#arg_text)
Current notif wasn't very informative, I updated it to only contain the project deployed, on which region and the status